### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -81,7 +81,7 @@ dependencies:
     - cycler==0.11.0
     - datasets==2.5.1
     - dill==0.3.5.1
-    - evaluate==0.2.2
+    - evaluate==0.3.0
     - flatbuffers==2.0.7
     - fonttools==4.37.3
     - frozenlist==1.3.1


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.